### PR TITLE
46Elks provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "jandreasn/an-sms",
   "type": "library",
   "description": "A PHP library to send and receive SMS text messages through various providers/gateways.",
-  "keywords": ["sms", "psms", "premium sms", "cellsynt", "twilio", "nexmo"],
+  "keywords": ["sms", "psms", "premium sms", "cellsynt", "twilio", "nexmo", "46elks"],
   "homepage": "http://github.com/jandreasn/an-sms",
   "license": "MIT",
   "authors": [

--- a/src/Gateway/Provider/FortySixElksGateway.php
+++ b/src/Gateway/Provider/FortySixElksGateway.php
@@ -98,7 +98,7 @@ class FortySixElksGateway extends AbstractHttpGateway implements GatewayInterfac
     {
         $data = [
             'from' => (string) $message->getFrom(),
-            'to' => '+' . $message->getTo(),
+            'to' => (string) $message->getTo(),
             'message' => $message->getText(),
         ];
 

--- a/src/Gateway/Provider/FortySixElksGateway.php
+++ b/src/Gateway/Provider/FortySixElksGateway.php
@@ -174,6 +174,5 @@ class FortySixElksGateway extends AbstractHttpGateway implements GatewayInterfac
         }
 
         return new DeliveryReport($data['id'], $data['status']);
-
     }
 }

--- a/src/Gateway/Provider/FortySixElksGateway.php
+++ b/src/Gateway/Provider/FortySixElksGateway.php
@@ -37,27 +37,27 @@ class FortySixElksGateway extends AbstractHttpGateway implements GatewayInterfac
     /**
      * @var string
      */
-    protected $username;
+    protected $apiUsername;
 
     /**
      * @var string
      */
-    protected $password;
+    protected $apiPassword;
 
     public function __construct(
-        string $username,
-        string $password,
+        string $apiUsername,
+        string $apiPassword,
         HttpClient $httpClient = null,
         MessageFactory $messageFactory = null
     ) {
         parent::__construct($httpClient, $messageFactory);
 
-        if (empty($username) || empty($password)) {
-            throw new \InvalidArgumentException('46 Elks username and password are required');
+        if (empty($apiUsername) || empty($apiPassword)) {
+            throw new \InvalidArgumentException('46 Elks api username and api password are required');
         }
 
-        $this->username = $username;
-        $this->password = $password;
+        $this->apiUsername = $apiUsername;
+        $this->apiPassword = $apiPassword;
     }
 
     /**
@@ -66,13 +66,12 @@ class FortySixElksGateway extends AbstractHttpGateway implements GatewayInterfac
      */
     public function sendMessage(MessageInterface $message): void
     {
-        $queryData = $this->buildSendQueryData($message);
-        $query = http_build_query($queryData);
+        $data = http_build_query($this->buildSendData($message));
         $request = $this->messageFactory->createRequest(
             'POST',
-            $this->getApiEndpoint(),
+            self::SMS_API_ENDPOINT,
             $this->getHeaders(),
-            $query
+            $data
         );
 
         try {
@@ -88,22 +87,22 @@ class FortySixElksGateway extends AbstractHttpGateway implements GatewayInterfac
     protected function getHeaders(): array
     {
         $headers = [
-            'Authorization' => 'Basic ' . base64_encode(sprintf('%s:%s', $this->username, $this->password)),
+            'Authorization' => 'Basic ' . base64_encode(sprintf('%s:%s', $this->apiUsername, $this->apiPassword)),
             'Content-type' => 'application/x-www-form-urlencoded',
         ];
 
         return $headers;
     }
 
-    protected function buildSendQueryData(MessageInterface $message): array
+    protected function buildSendData(MessageInterface $message): array
     {
-        $queryData = [
+        $data = [
             'from' => (string) $message->getFrom(),
             'to' => '+' . $message->getTo(),
             'message' => $message->getText(),
         ];
 
-        return $queryData;
+        return $data;
     }
 
     protected function getApiEndpoint(): string

--- a/src/Gateway/Provider/FortySixElksGateway.php
+++ b/src/Gateway/Provider/FortySixElksGateway.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types=1);
+
+/**
+ * An SMS library.
+ *
+ * @copyright Copyright (c) 2017 Andreas Nilsson
+ * @license   MIT
+ */
+
+namespace AnSms\Gateway\Provider;
+
+use AnSms\Gateway\AbstractHttpGateway;
+use AnSms\Gateway\GatewayInterface;
+use AnSms\Exception\ReceiveException;
+use AnSms\Exception\SendException;
+use AnSms\Message\Address\AddressInterface;
+use AnSms\Message\Address\Alphanumeric;
+use AnSms\Message\Address\ShortCode;
+use AnSms\Message\Message;
+use AnSms\Message\MessageInterface;
+use AnSms\Message\DeliveryReport\DeliveryReportInterface;
+use AnSms\Message\DeliveryReport\DeliveryReport;
+use AnSms\Message\PremiumMessageInterface;
+use Http\Client\Exception\TransferException;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
+
+/**
+ * 46Elks SMS gateway provider.
+ *
+ * @author Jon Gotlin <http://github.com/jongotlin>
+ */
+class FortySixElksGateway extends AbstractHttpGateway implements GatewayInterface
+{
+    protected const SMS_API_ENDPOINT = 'https://api.46elks.com/a1/SMS';
+
+    /**
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * @var string
+     */
+    protected $password;
+
+    public function __construct(
+        string $username,
+        string $password,
+        HttpClient $httpClient = null,
+        MessageFactory $messageFactory = null
+    ) {
+        parent::__construct($httpClient, $messageFactory);
+
+        if (empty($username) || empty($password)) {
+            throw new \InvalidArgumentException('46 Elks username and password are required');
+        }
+
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    /**
+     * @param MessageInterface $message
+     * @throws SendException
+     */
+    public function sendMessage(MessageInterface $message): void
+    {
+        $queryData = $this->buildSendQueryData($message);
+        $query = http_build_query($queryData);
+        $request = $this->messageFactory->createRequest(
+            'POST',
+            $this->getApiEndpoint(),
+            $this->getHeaders(),
+            $query
+        );
+
+        try {
+            $response = $this->httpClient->sendRequest($request);
+            $content = (string) $response->getBody();
+
+            $trackingId = $this->parseSendResponseContent($content);
+            $message->setId($trackingId);
+        } catch (TransferException $e) {
+            throw new SendException($e->getMessage(), 0, $e);
+        }
+    }
+
+    protected function getHeaders(): array
+    {
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode(sprintf('%s:%s', $this->username, $this->password)),
+            'Content-type' => 'application/x-www-form-urlencoded',
+        ];
+
+        return $headers;
+    }
+
+    protected function buildSendQueryData(MessageInterface $message): array
+    {
+        $queryData = [
+            'from' => (string) $message->getFrom(),
+            'to' => '+' . $message->getTo(),
+            'message' => $message->getText(),
+        ];
+
+        return $queryData;
+    }
+
+    protected function getApiEndpoint(): string
+    {
+        return static::SMS_API_ENDPOINT;
+    }
+
+    /**
+     * @param string $content
+     * @throws SendException
+     * @return string
+     */
+    protected function parseSendResponseContent(string $content): string
+    {
+        $result = json_decode($content, true);
+        if (!is_array($result)) {
+            throw new SendException('Send message failed with error: ' . $content);
+        } elseif (!isset($result['status']) || $result['status'] != 'created') {
+            throw new SendException('Send message failed with missing status value: ' . $content);
+        } elseif (!isset($result['id'])) {
+            throw new SendException('Message sent but missing id in response: ' . $content);
+        }
+
+        return $result['id'];
+    }
+
+    /**
+     * @param Message[] $messages
+     * @throws SendException
+     */
+    public function sendMessages(array $messages): void
+    {
+        foreach ($messages as $message) {
+            $this->sendMessage($message);
+        }
+    }
+
+    public function receiveMessage($data): MessageInterface
+    {
+        // @todo
+    }
+
+    public function receiveDeliveryReport($data): DeliveryReportInterface
+    {
+        // @todo
+    }
+}

--- a/src/Gateway/Provider/FortySixElksGateway.php
+++ b/src/Gateway/Provider/FortySixElksGateway.php
@@ -105,11 +105,6 @@ class FortySixElksGateway extends AbstractHttpGateway implements GatewayInterfac
         return $data;
     }
 
-    protected function getApiEndpoint(): string
-    {
-        return static::SMS_API_ENDPOINT;
-    }
-
     /**
      * @param string $content
      * @throws SendException

--- a/src/Gateway/Provider/FortySixElksGateway.php
+++ b/src/Gateway/Provider/FortySixElksGateway.php
@@ -122,7 +122,7 @@ class FortySixElksGateway extends AbstractHttpGateway implements GatewayInterfac
         $result = json_decode($content, true);
         if (!is_array($result)) {
             throw new SendException('Send message failed with error: ' . $content);
-        } elseif (!isset($result['status']) || $result['status'] != 'created') {
+        } elseif (!isset($result['status']) || !in_array($result['status'], ['created', 'sent', 'delivered'])) {
             throw new SendException('Send message failed with missing status value: ' . $content);
         } elseif (!isset($result['id'])) {
             throw new SendException('Message sent but missing id in response: ' . $content);

--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -41,10 +41,15 @@ abstract class AbstractMessage implements MessageInterface
      */
     protected $operator;
 
-     /**
+    /**
      * @var string|null
      */
     protected $countryCode;
+
+    /**
+     * @var int|null
+     */
+    protected $segmentCount;
 
     /**
      * @param AddressInterface      $to   The recipient's number
@@ -70,8 +75,8 @@ abstract class AbstractMessage implements MessageInterface
 
     public function setText(string $text): void
     {
-        if (empty($text) || mb_strlen($text) > 160) {
-            throw new \InvalidArgumentException('Text is required and can not be more than 160 characters long');
+        if (empty($text)) {
+            throw new \InvalidArgumentException('Text is required');
         }
 
         $this->text = $text;
@@ -122,6 +127,16 @@ abstract class AbstractMessage implements MessageInterface
         return $this->countryCode;
     }
 
+    public function getSegmentCount(): ?int
+    {
+        return $this->segmentCount;
+    }
+
+    public function setSegmentCount(int $segmentCount): void
+    {
+        $this->segmentCount = $segmentCount;
+    }
+
     public function getLogContext(): array
     {
         return array_filter([
@@ -131,6 +146,7 @@ abstract class AbstractMessage implements MessageInterface
             'id' => $this->getId(),
             'operator' => $this->getOperator(),
             'countryCode' => $this->getCountryCode(),
+            'segmentCount' => $this->getSegmentCount(),
         ]);
     }
 }

--- a/src/Message/MessageInterface.php
+++ b/src/Message/MessageInterface.php
@@ -43,4 +43,8 @@ interface MessageInterface
     public function setCountryCode(string $countryCode): void;
 
     public function getCountryCode(): ?string;
+
+    public function setSegmentCount(int $segmentCount): void;
+
+    public function getSegmentCount(): ?int;
 }

--- a/tests/Gateway/Provider/FortySixElksGatewayTest.php
+++ b/tests/Gateway/Provider/FortySixElksGatewayTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Unit\Gateway\Provider;
+
+use AnSms\Exception\SendException;
+use AnSms\Gateway\Provider\FortySixElksGateway;
+use AnSms\Message\Message;
+use AnSms\Message\MessageInterface;
+use Http\Message\MessageFactory;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Psr\Http\Message\RequestInterface;
+use Http\Adapter\Guzzle6\Client;
+use Psr\Http\Message\ResponseInterface;
+
+class FortySixElksGatewayTest extends TestCase
+{
+    /**
+     * @var FortySixElksGateway
+     */
+    private $gateway;
+
+    /**
+     * @var MessageFactory|MockObject
+     */
+    private $messageFactoryMock;
+
+    /**
+     * @var Client|MockObject
+     */
+    private $clientMock;
+
+    protected function setUp()
+    {
+        $this->clientMock = $this->createMock(Client::class);
+        $this->messageFactoryMock = $this->createMock(MessageFactory::class);
+
+        $this->gateway = new FortySixElksGateway(
+            'some-username',
+            'some-password',
+            $this->clientMock,
+            $this->messageFactoryMock
+        );
+    }
+
+    public function testCreateGatewayWithInvalidCredentials()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new FortySixElksGateway('', '');
+    }
+
+    public function testSendMessage()
+    {
+        $message = Message::create('46700123001', 'Hello world!', 'Forty6Elks');
+
+        $url = 'https://api.46elks.com/a1/SMS';
+        $headers = [
+            'Authorization' => 'Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk',
+            'Content-type' => 'application/x-www-form-urlencoded',
+        ];
+        $query = 'from=Forty6Elks&to=%2B46700123001&message=Hello+world%21';
+
+        $requestMock = $this->createMock(RequestInterface::class);
+        $this->messageFactoryMock->expects($this->once())
+            ->method('createRequest')->with('POST', $url, $headers, $query)->willReturn($requestMock);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $this->clientMock->expects($this->once())->method('sendRequest')->willReturn($responseMock);
+
+        $responseMock->method('getBody')->willReturn('{"status": "created", "direction": "outgoing", "from": "Forty6Elks", "created": "2018-09-27T06:50:35.559577", "parts": 1, "to": "+46700123001", "cost": 3500, "message": "Hello world!", "id": "a95b04cf23d7f94c508e675b38eb46934"}');
+
+        $this->gateway->sendMessage($message);
+    }
+
+    public function testSendMessageWithInvalidJsonGeneratesError()
+    {
+        $messageMock = $this->createMock(MessageInterface::class);
+
+        $requestMock = $this->createMock(RequestInterface::class);
+        $this->messageFactoryMock->method('createRequest')->willReturn($requestMock);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $this->clientMock->expects($this->once())->method('sendRequest')->willReturn($responseMock);
+
+        $responseMock->method('getBody')->willReturn('Some error message');
+
+        $this->expectException(SendException::class);
+        $this->expectExceptionMessage('Send message failed with error: Some error message');
+        $this->gateway->sendMessage($messageMock);
+    }
+
+    public function testSendMessageResonseWithMissingStatusKeyGeneratesError()
+    {
+        $messageMock = $this->createMock(MessageInterface::class);
+
+        $requestMock = $this->createMock(RequestInterface::class);
+        $this->messageFactoryMock->method('createRequest')->willReturn($requestMock);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $this->clientMock->expects($this->once())->method('sendRequest')->willReturn($responseMock);
+
+        $responseMock->method('getBody')->willReturn('{}');
+
+        $this->expectException(SendException::class);
+        $this->expectExceptionMessage('Send message failed with missing status value: {}');
+        $this->gateway->sendMessage($messageMock);
+    }
+
+    public function testSendMessageResonseWithMissingIdKeyGeneratesError()
+    {
+        $messageMock = $this->createMock(MessageInterface::class);
+
+        $requestMock = $this->createMock(RequestInterface::class);
+        $this->messageFactoryMock->method('createRequest')->willReturn($requestMock);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $this->clientMock->expects($this->once())->method('sendRequest')->willReturn($responseMock);
+
+        $responseMock->method('getBody')->willReturn('{"status": "created"}');
+
+        $this->expectException(SendException::class);
+        $this->expectExceptionMessage('Message sent but missing id in response: {"status": "created"}');
+        $this->gateway->sendMessage($messageMock);
+    }
+
+    public function testSendMessages()
+    {
+        $messages = [
+            Message::create('46700123001', 'Hello world!', 'Forty6Elks'),
+            Message::create('46700123001', 'Hello world!', 'Forty6Elks'),
+        ];
+
+        $requestMock = $this->createMock(RequestInterface::class);
+        $this->messageFactoryMock->method('createRequest')->willReturn($requestMock);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $this->clientMock->expects($this->exactly(2))->method('sendRequest')->willReturn($responseMock);
+
+        $responseMock->method('getBody')->willReturn('{"status": "created", "direction": "outgoing", "from": "Forty6Elks", "created": "2018-09-27T06:50:35.559577", "parts": 1, "to": "+46700123001", "cost": 3500, "message": "Hello world!", "id": "a95b04cf23d7f94c508e675b38eb46934"}');
+
+        $this->gateway->sendMessages($messages);
+    }
+}

--- a/tests/Gateway/Provider/FortySixElksGatewayTest.php
+++ b/tests/Gateway/Provider/FortySixElksGatewayTest.php
@@ -59,7 +59,7 @@ class FortySixElksGatewayTest extends TestCase
             'Authorization' => 'Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk',
             'Content-type' => 'application/x-www-form-urlencoded',
         ];
-        $query = 'from=Forty6Elks&to=%2B46700123001&message=Hello+world%21';
+        $query = 'from=Forty6Elks&to=46700123001&message=Hello+world%21';
 
         $requestMock = $this->createMock(RequestInterface::class);
         $this->messageFactoryMock->expects($this->once())

--- a/tests/Message/MessageTest.php
+++ b/tests/Message/MessageTest.php
@@ -14,6 +14,7 @@ class MessageTest extends TestCase
     private const TEST_ID = '12345';
     private const TEST_OPERATOR = 'Company';
     private const TEST_COUNTRY_CODE = 'SE';
+    private const SEGMENT_COUNT = 1;
 
     /**
      * @var Message
@@ -31,6 +32,7 @@ class MessageTest extends TestCase
         $this->message->setId(self::TEST_ID);
         $this->message->setOperator(self::TEST_OPERATOR);
         $this->message->setCountryCode(self::TEST_COUNTRY_CODE);
+        $this->message->setSegmentCount(self::SEGMENT_COUNT);
     }
 
     public function testMessageCanBeCreated()
@@ -54,14 +56,6 @@ class MessageTest extends TestCase
         $this->message->setText($newText);
 
         $this->assertSame($newText, $this->message->getText());
-    }
-
-    public function testTextCantBeTooLong()
-    {
-        $newText = str_repeat('s', 161);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->message->setText($newText);
     }
 
     public function testFromCanBeSet()
@@ -100,12 +94,13 @@ class MessageTest extends TestCase
     {
          $this->assertSame(
              [
-                'to' => self::TEST_TO,
-                'text' => self::TEST_TEXT,
-                'from' => self::TEST_FROM,
-                'id' => self::TEST_ID,
-                'operator' => self::TEST_OPERATOR,
-                'countryCode' => self::TEST_COUNTRY_CODE,
+                 'to' => self::TEST_TO,
+                 'text' => self::TEST_TEXT,
+                 'from' => self::TEST_FROM,
+                 'id' => self::TEST_ID,
+                 'operator' => self::TEST_OPERATOR,
+                 'countryCode' => self::TEST_COUNTRY_CODE,
+                 'segmentCount' => self::SEGMENT_COUNT,
              ],
              $this->message->getLogContext()
          );


### PR DESCRIPTION
Hi Andreas!

I started to implement 46elks as provider.

In my use case I need number of segments/parts for each sms. That would imply adding `getSegments()` to `MessageInterface`. What do you think?

Both 46Elks and Twilio supports this. I don't know about the other providers.
https://46elks.se/docs/send-sms
https://www.twilio.com/docs/sms/send-messages#send-an-sms-with-twilios-api