### PR TITLE
Telenor Gateway: Add support for specifying a delivery status url

### DIFF
--- a/src/Gateway/TelenorGateway.php
+++ b/src/Gateway/TelenorGateway.php
@@ -41,6 +41,7 @@ class TelenorGateway extends AbstractHttpGateway implements GatewayInterface
         ?ClientInterface $httpClient = null,
         ?RequestFactoryInterface $requestFactory = null,
         ?StreamFactoryInterface $streamFactory = null,
+        protected ?string $statusDeliveryUrl = null,
     ) {
         parent::__construct($httpClient, $requestFactory, $streamFactory);
 
@@ -96,6 +97,9 @@ class TelenorGateway extends AbstractHttpGateway implements GatewayInterface
         }
         if ($this->supplementaryInformation !== null) {
             $header->appendChild($xml->createElement('sub_id_1', $this->supplementaryInformation));
+        }
+        if ($this->statusDeliveryUrl !== null) {
+            $header->appendChild($xml->createElement('status_delivery_url', $this->statusDeliveryUrl));
         }
         $mobileCtrlSms->appendChild($header);
 


### PR DESCRIPTION
According to [Telenor docs](https://www.telenor.se/globalassets/mediabibliotek/telenor-foretag/pdf/losningar/sms-pro-api-interface-specification-version-3.3.1.pdf) we can send a header value `delivery_status_url` which will be used as the endpoint where delivery reports are sent to.

This is needed for an app of ours where we need to specify a custom endpoint since the Telenor account is shared for multiple projects.

I put this in the constructor to match how the `$supplementaryInformation` argument is used, but I put it last since this would technically otherwise be a breaking change warranting a new major.

If you think we should put the argument before the mocks, please tell me and I will update the PR.